### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/RaceFrontend/amplify/backend/function/raceDataReceiver/raceDataReceiver-cloudformation-template.json
+++ b/RaceFrontend/amplify/backend/function/raceDataReceiver/raceDataReceiver-cloudformation-template.json
@@ -99,7 +99,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/RaceFrontend/amplify/backend/function/raceOperations/raceOperations-cloudformation-template.json
+++ b/RaceFrontend/amplify/backend/function/raceOperations/raceOperations-cloudformation-template.json
@@ -105,7 +105,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }


### PR DESCRIPTION
CloudFormation templates in realtime-slot-car-racing-with-aws-amplify-aws-iot-core-and-amazon-kinesis-video-streams have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.